### PR TITLE
Update Prettier config by removing overrides

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,10 +7,9 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[package.json]
-indent_style = space
-indent_size = 2
+[*.md]
+trim_trailing_whitespace = false
 
-[*.{md,css,yml}]
+[*.yml]
 indent_style = space
 indent_size = 2

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -7,16 +7,4 @@ module.exports = {
 	singleQuote: true,
 	trailingComma: 'all',
 	useTabs: true,
-	overrides: [
-		{
-			files: ['*.md'],
-			options: {
-				printWidth: 80,
-				singleQuote: false,
-				tabWidth: 2,
-				trailingComma: 'none',
-				useTabs: false,
-			},
-		},
-	],
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -9,7 +9,7 @@ module.exports = {
 	useTabs: true,
 	overrides: [
 		{
-			files: ['package.json', 'package-lock.json', '*.md'],
+			files: ['*.md'],
 			options: {
 				printWidth: 80,
 				singleQuote: false,

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your `package.json`:
 
 ```json
 {
-  "prettier": "@stylelint/prettier-config"
+	"prettier": "@stylelint/prettier-config"
 }
 ```
 


### PR DESCRIPTION
This PR removes the existing overrides from the configuration and updates the EditorConfig file to match:

I'll post notes explaining the reasoning behind this changes as PR comments

Using the [hide whitespace diff view](https://github.com/stylelint/prettier-config/pull/7/files?diff=unified&w=1) is also helpful
