### PR TITLE
Remove support for older Node.js versions than `14.18.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Head
 
 - Removed: Prettier 2 support.
+- Removed: support for older Node.js versions than `14.18.0`.
 - Changed: package type to pure ESM.
 
 ## 2.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.0"
       },
+      "engines": {
+        "node": ">= 14.18"
+      },
       "peerDependencies": {
         "prettier": ">=3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
   "peerDependencies": {
     "prettier": ">=3.0.0"
   },
+  "engines": {
+    "node": ">=14.18.0"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #22

> Is there anything in the PR that needs further explanation?

`np` (`npm run release`) now requires the `engines.node` field in `package.json`,
so this change adds the field. The minimum version is determined by `ls-engines`.

```console
$ npx ls-engines@latest
...
┌────────────────────────┬───────────────────────────┐
│ package engines:       │ dependency graph engines: │
├────────────────────────┼───────────────────────────┤
│ "engines": {           │ "engines": {              │
│   "node": ">= 14.18.0" │   "node": ">= 14.18"      │
│ }                      │ }                         │
└────────────────────────┴───────────────────────────┘
...
Your “engines” field exactly matches your dependency graph’s requirements!
```
