### PR TITLE
Exclude `prettier` from `dev-deps` group in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     groups:
       dev-deps:
         dependency-type: 'development'
+        exclude-patterns: ['prettier']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #28

> Is there anything in the PR that needs further explanation?

`prettier` is defined as a peer dependency, so it should not be updated along with other dev dependencies.

https://github.com/stylelint/prettier-config/blob/3c5dc68a4ca1e05f4b9b83a36da6dca7ebd98811/package.json#L47-L49
