### PR TITLE
Fix `husky install` deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "npm-run-all --parallel lint:*",
     "lint:formatting": "prettier . --check",
     "lint:js": "eslint",
-    "prepare": "husky install",
+    "prepare": "husky",
     "release": "np",
     "test": "npm run lint"
   },


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #32
> Is there anything in the PR that needs further explanation?

The latest husky has deprecated the `husky install` command:

```
husky - install command is DEPRECATED
```
