### PR TITLE
Remove support for older Node.js versions than `20.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Removed: support for older Node.js versions than `20.0.0`.
+
 ## 3.0.0
 
 - Removed: Prettier 2 support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "prettier": "^3.6.2"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "prettier": ">=3.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": ">=3.0.0"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js v20 is the minimum active version.
Ref https://endoflife.date/nodejs
